### PR TITLE
fix: handle nullish values in storage getters

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -72,7 +72,7 @@ export const storage = {
 
   async getActiveWorkspace(): Promise<string | null> {
     const result = await chrome.storage.local.get(STORAGE_KEYS.ACTIVE_WORKSPACE)
-    return result[STORAGE_KEYS.ACTIVE_WORKSPACE] || null
+    return result[STORAGE_KEYS.ACTIVE_WORKSPACE] ?? null
   },
 
   async setActiveWorkspace(id: string | null): Promise<void> {
@@ -105,7 +105,7 @@ export const storage = {
 
   async getPreviousTabId(): Promise<number | null> {
     const result = await chrome.storage.local.get(STORAGE_KEYS.PREVIOUS_TAB_ID)
-    return result[STORAGE_KEYS.PREVIOUS_TAB_ID] || null
+    return result[STORAGE_KEYS.PREVIOUS_TAB_ID] ?? null
   },
 
   async setPreviousTabId(tabId: number | null): Promise<void> {


### PR DESCRIPTION
## Summary
- use nullish coalescing when retrieving active workspace and previous tab ID from storage

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run typecheck` *(fails: type errors in TabList.tsx, TabRules.tsx, WorkspaceView.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689584a3a2f083258c05482060cd1983